### PR TITLE
Spec rgb softmax

### DIFF
--- a/submission.ipynb
+++ b/submission.ipynb
@@ -7,7 +7,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/mitsu-h/BirdCLEF/blob/make_train_note/submission.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/mitsu-h/BirdCLEF/blob/spec_rgb_softmax/submission.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -26,7 +26,7 @@
       "cell_type": "code",
       "source": [
         "ENV=\"dev\"\n",
-        "model_name = \"best_model_202204010500.pth.tar\""
+        "model_name = \"best_model_202204040626.pth.tar\""
       ],
       "metadata": {
         "id": "5B-4nSlxrLpa"
@@ -485,9 +485,10 @@
       "outputs": [],
       "source": [
         "# Convert augmented audio to Mel Spectrogram\n",
-        "def mel_spec(aud, n_mels=64, n_fft=1024, hop_len=None):\n",
+        "def mel_spec(aud, n_mels=128, n_fft=None, hop_len=None):\n",
         "    sig, sr = aud\n",
         "    top_db = 80\n",
+        "    n_fft = n_fft or sr // 10\n",
         "    \n",
         "    spec = transforms.MelSpectrogram(sr, n_fft=n_fft, hop_length=hop_len, n_mels=n_mels)(sig)\n",
         "    # shape of spec: (channels, n_mels, time)\n",
@@ -500,6 +501,36 @@
         "    return spec"
       ],
       "id": "6403bcd7"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def mono_to_color(X, eps=1e-6, mean=None, std=None):\n",
+        "    mean = mean or X.mean()\n",
+        "    std = std or X.std()\n",
+        "    X = (X - mean) / (std + eps)\n",
+        "    \n",
+        "    _min, _max = X.min(), X.max()\n",
+        "\n",
+        "    if (_max - _min) > eps:\n",
+        "        V = torch.clip(X, _min, _max)\n",
+        "        V = 255 * (V - _min) / (_max - _min)\n",
+        "        V = V.to(torch.uint8)\n",
+        "    else:\n",
+        "        V = torch.zeros_like(X, dtype=torch.uint8)\n",
+        "\n",
+        "    return V\n",
+        "\n",
+        "def normalize(image):\n",
+        "        image = image.to(torch.float32) / 255.0\n",
+        "        return image  \n"
+      ],
+      "metadata": {
+        "id": "N55AKb4i0sLT"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "id": "N55AKb4i0sLT"
     },
     {
       "cell_type": "code",
@@ -634,10 +665,10 @@
         "        audio = time_shift(audio, shift_limit=self.shift_limit)\n",
         "\n",
         "        # Convert to Mel Spectrogram\n",
-        "        spec = mel_spec(audio)\n",
-        "        \n",
-        "        # resize Mel Spec\n",
-        "        spec = torchvision.transforms.Resize((self.input_size, self.input_size))(spec)\n",
+        "        spec = mono_to_color(mel_spec(audio))\n",
+        "\n",
+        "        # Normarize\n",
+        "        spec = normalize(spec)\n",
         "\n",
         "        # Augment mel spec\n",
         "        aug_spec = spectro_augment(spec)\n",
@@ -820,13 +851,13 @@
       "cell_type": "code",
       "source": [
         "def create_model(labels, device):\n",
-        "  model = torchvision.models.resnet50(num_classes=len(labels))\n",
+        "  model = torchvision.models.resnet50(pretrained=True)\n",
         "  model.fc = torch.nn.Sequential(\n",
         "    torch.nn.Linear(\n",
         "        in_features=model.fc.in_features,\n",
-        "        out_features=model.fc.out_features\n",
+        "        out_features=len(labels)\n",
         "    ),\n",
-        "    torch.nn.Sigmoid()\n",
+        "    torch.nn.Softmax()\n",
         "  )\n",
         "  return model.to(device)"
       ],

--- a/train.ipynb
+++ b/train.ipynb
@@ -7,7 +7,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/mitsu-h/BirdCLEF/blob/make_train_note/train.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/mitsu-h/BirdCLEF/blob/spec_rgb_softmax/train.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -929,9 +929,10 @@
       "outputs": [],
       "source": [
         "# Convert augmented audio to Mel Spectrogram\n",
-        "def mel_spec(aud, n_mels=64, n_fft=1024, hop_len=None):\n",
+        "def mel_spec(aud, n_mels=128, n_fft=None, hop_len=None):\n",
         "    sig, sr = aud\n",
         "    top_db = 80\n",
+        "    n_fft = n_fft or sr // 10\n",
         "    \n",
         "    spec = transforms.MelSpectrogram(sr, n_fft=n_fft, hop_length=hop_len, n_mels=n_mels)(sig)\n",
         "    # shape of spec: (channels, n_mels, time)\n",
@@ -943,6 +944,36 @@
         "    spec = torch.cat([spec, spec.mean(dim=0, keepdim=True)])\n",
         "    return spec"
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def mono_to_color(X, eps=1e-6, mean=None, std=None):\n",
+        "    mean = mean or X.mean()\n",
+        "    std = std or X.std()\n",
+        "    X = (X - mean) / (std + eps)\n",
+        "    \n",
+        "    _min, _max = X.min(), X.max()\n",
+        "\n",
+        "    if (_max - _min) > eps:\n",
+        "        V = torch.clip(X, _min, _max)\n",
+        "        V = 255 * (V - _min) / (_max - _min)\n",
+        "        V = V.to(torch.uint8)\n",
+        "    else:\n",
+        "        V = torch.zeros_like(X, dtype=torch.uint8)\n",
+        "\n",
+        "    return V\n",
+        "\n",
+        "def normalize(image):\n",
+        "        image = image.to(torch.float32) / 255.0\n",
+        "        return image  \n"
+      ],
+      "metadata": {
+        "id": "N55AKb4i0sLT"
+      },
+      "id": "N55AKb4i0sLT",
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -1042,10 +1073,10 @@
         "audio = time_shift(audio, shift_limit=0.4)\n",
         "\n",
         "# Convert to Mel Spectrogram\n",
-        "spec = mel_spec(audio)\n",
+        "spec = mono_to_color(mel_spec(audio))\n",
         "\n",
-        "# resize Mel Spec\n",
-        "spec = torchvision.transforms.Resize((224, 224))(spec)\n",
+        "# Normarize\n",
+        "spec = normalize(spec)\n",
         "\n",
         "# Augment on mel spec\n",
         "aug_spec = spectro_augment(spec)\n",
@@ -1079,6 +1110,7 @@
         "aug_spec_np = aug_spec.permute(1,2,0).numpy()\n",
         "f, ax = plt.subplots(figsize=(15,8))\n",
         "plt.imshow(aug_spec_np[:, :, 0])\n",
+        "plt.colorbar()\n",
         "plt.show()\n",
         "f, ax = plt.subplots(figsize=(15,8))\n",
         "plt.imshow(aug_spec_np[:, :, 1])\n",
@@ -1162,10 +1194,10 @@
         "        audio = time_shift(audio, shift_limit=self.shift_limit)\n",
         "\n",
         "        # Convert to Mel Spectrogram\n",
-        "        spec = mel_spec(audio)\n",
-        "        \n",
-        "        # resize Mel Spec\n",
-        "        spec = torchvision.transforms.Resize((self.input_size, self.input_size))(spec)\n",
+        "        spec = mono_to_color(mel_spec(audio))\n",
+        "\n",
+        "        # Normarize\n",
+        "        spec = normalize(spec)\n",
         "\n",
         "        # Augment mel spec\n",
         "        aug_spec = spectro_augment(spec)\n",
@@ -1358,13 +1390,13 @@
       "cell_type": "code",
       "source": [
         "def create_model(labels, device):\n",
-        "  model = torchvision.models.resnet50(num_classes=len(labels))\n",
+        "  model = torchvision.models.resnet50(pretrained=True)\n",
         "  model.fc = torch.nn.Sequential(\n",
         "    torch.nn.Linear(\n",
         "        in_features=model.fc.in_features,\n",
-        "        out_features=model.fc.out_features\n",
+        "        out_features=len(labels)\n",
         "    ),\n",
-        "    torch.nn.Sigmoid()\n",
+        "    torch.nn.Softmax()\n",
         "  )\n",
         "  return model.to(device)"
       ],
@@ -1795,6 +1827,7 @@
     "colab": {
       "name": "train.ipynb",
       "provenance": [],
+      "private_outputs": true,
       "include_colab_link": true
     },
     "accelerator": "GPU"


### PR DESCRIPTION
以下の実装を行いました。確認お願いします。
[動作確認用の学習済みモデル](https://drive.google.com/file/d/1-0LtEoudmy7puIleGPPTYyhWkm0zyn0d/view?usp=sharing)

- メルスペクトログラムを0-255のuint8に変換
- メルスペクトログラムの`n_mels`, `n_fft`の調整
    - 次元数の圧縮のため
- torchvisionのモデル読み込み箇所の修正
    - 今までの実装だと、pretrained_modelが読み込まれてなかったため
- 最後の活性化関数をSoftmaxに変更

Closes #3 Closes #8